### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Alternative to UIActivityViewController compatible with iOS5.0
 
 
 ### Requirements
-* XCode 4.4+
+* Xcode 4.4+
 * Deployment Target iOS5.0+
 * ARC
  


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
